### PR TITLE
Change data source to .rds

### DIFF
--- a/R/mod_bivariate_bar.R
+++ b/R/mod_bivariate_bar.R
@@ -8,8 +8,8 @@ select_choices <- c(
   ,"mos_ethnicity"  ="mos_ethnicity"
   ,"mos_gender"  ="mos_gender"
   ,"mos_age_incident"  ="mos_age_incident"
-  ,"complainant_ethnicity"  ="complainant_ethnicity"
-  ,"complainant_gender"  ="complainant_gender"
+  ,"complainant_ethnicity"  ="complainant_ethnicity5"
+  ,"complainant_gender"  ="complainant_gender4"
   ,"complainant_age_incident" = "complainant_age_incident"
 )
 

--- a/data-raw/nypd-ccrb-clean.R
+++ b/data-raw/nypd-ccrb-clean.R
@@ -5,9 +5,9 @@
 # TODO: Update App data source to match NYPD-CCRB-2020 Repo
 
 
-path_input <- "./data-raw/nypd-ccrb-cleaned.csv"
+path_input <- "./data-raw/nypd-ccrb-cleaned.rds"
 
-nypd_ccrb_cleaned <- readr::read_csv(path_input)
+nypd_ccrb_cleaned <- readr::read_rds(path_input)
 
 
 # ---- save-data ---------------------------------------------------------------


### PR DESCRIPTION
@mmmmtoasty19 , please re-map the data source to .rds, instead of .csv. The .rds preserves the order of the factor levels and other column features created by `nypd-ccrb-2020/analysis/1-first-look.R` script. This is particularly important in displaying `rank_now` and `rank_incident` variables